### PR TITLE
Application now compiles on Mac OSX (Yosemite).

### DIFF
--- a/src/ce_common.pas
+++ b/src/ce_common.pas
@@ -6,7 +6,7 @@ interface
 
 uses
 
-  Classes, SysUtils, StrUtils,
+  Classes, SysUtils,
   {$IFDEF WINDOWS}
   Windows, JwaTlHelp32,
   {$ENDIF}
@@ -939,7 +939,7 @@ begin
     lst := TStringList.Create;
     try
       lst.LoadFromStream(proc.Output);
-      Result := StrToInt(Trim(lst.Text));
+      Result := StrToIntDef(Trim(lst.Text), 0);
     finally
       lst.Free;
     end;

--- a/src/ce_common.pas
+++ b/src/ce_common.pas
@@ -659,6 +659,18 @@ begin
     Free;
   end;
   {$ENDIF}
+  {$IFDEF DARWIN}
+  with TProcess.Create(nil) do
+  try
+    Executable := 'open';
+    Parameters.Add(aFilename);
+    Execute;
+  finally
+    result := true;
+    Free;
+  end;
+  {$ENDIF}
+
 end;
 
 function exeInSysPath(anExeName: string): boolean;
@@ -916,11 +928,8 @@ function internalAppIsRunning(const ExeName: string): integer;
 var
   proc: TProcess;
   lst: TStringList;
-  stripChars: TSysCharSet;
-  lstText: AnsiString;
 begin
   Result := 0;
-  stripChars := ['"'];
   proc := tprocess.Create(nil);
   proc.Executable := 'pgrep';
   proc.Parameters.Add(ExeName);
@@ -930,9 +939,7 @@ begin
     lst := TStringList.Create;
     try
       lst.LoadFromStream(proc.Output);
-      lstText := lst.Text;
-      RemoveLeadingChars(lstText, stripChars);
-      Result := StrToInt(lstText);
+      Result := StrToInt(Trim(lst.Text));
     finally
       lst.Free;
     end;

--- a/src/ce_common.pas
+++ b/src/ce_common.pas
@@ -6,7 +6,7 @@ interface
 
 uses
 
-  Classes, SysUtils,
+  Classes, SysUtils, StrUtils,
   {$IFDEF WINDOWS}
   Windows, JwaTlHelp32,
   {$ENDIF}
@@ -910,6 +910,39 @@ begin
   end;
 end;
 {$ENDIF}
+
+{$IFDEF DARWIN}
+function internalAppIsRunning(const ExeName: string): integer;
+var
+  proc: TProcess;
+  lst: TStringList;
+  stripChars: TSysCharSet;
+  var lstText: AnsiString;
+begin
+  Result := 0;
+  stripChars := ['"'];
+  proc := tprocess.Create(nil);
+  proc.Executable := 'pgrep';
+  proc.Parameters.Add(ExeName);
+  proc.Options := [poUsePipes, poWaitonexit];
+  try
+    proc.Execute;
+    lst := TStringList.Create;
+    try
+      lst.LoadFromStream(proc.Output);
+      lstText := lst.Text;
+      RemoveLeadingChars(lstText, stripChars);
+      Result := StrToInt(lstText);
+    finally
+      lst.Free;
+    end;
+  finally
+    proc.Free;
+  end;
+end;
+{$ENDIF}
+
+
 
 function AppIsRunning(const ExeName: string):Boolean;
 begin

--- a/src/ce_common.pas
+++ b/src/ce_common.pas
@@ -917,7 +917,7 @@ var
   proc: TProcess;
   lst: TStringList;
   stripChars: TSysCharSet;
-  var lstText: AnsiString;
+  lstText: AnsiString;
 begin
   Result := 0;
   stripChars := ['"'];


### PR DESCRIPTION
Added `internalAppIsRunning` procedure for Darwin.

Uses `pgrep` instead of `ps` as MacOSX's ps lacks the `-C` option.
Instead we will use `pgrep` to query for the applications pid. If the
application is running we will get a positive integer (as a string) in
return which is returned as the `Result` after casting to `Int`.

Also: my first ever ObjectPascal code ;) Hooray!