### PR TITLE
Update RPM generation

### DIFF
--- a/cesetup/rpm.sh
+++ b/cesetup/rpm.sh
@@ -23,7 +23,7 @@ echo "[Desktop Entry]
 Categories=Application;IDE;Development;
 Exec=coedit %f
 GenericName=coedit
-Icon=/usr/share/pixmaps/coedit.png
+Icon=coedit
 Keywords=editor;Dlang;IDE;dmd;
 Name=coedit
 StartupNotify=true
@@ -35,7 +35,7 @@ echo "Name: coedit
 Version: $maj
 Release: $min
 Summary: IDE for the D programming language
-License: Boost Software License version 1
+License: Boost
 URL: www.github.com/BBasile/Coedit
 
 %description


### PR DESCRIPTION
Upon installing the RPM on Fedora, Gnome Software displays Coedit as proprietary software because the license in the RPM is not the license's short name.
Additionally, the icon name doesn't need to be a full path to the icon file since the icon is in `/usr/share/pixmaps`, and it's often better to just use the icon name (in case of icon theming and such).